### PR TITLE
Remove zeroing out of a Box<>

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -17,7 +17,6 @@ pub struct FileSystemRegistration<T: FileSystem> {
 impl<T: FileSystem> Drop for FileSystemRegistration<T> {
     fn drop(&mut self) {
         unsafe { bindings::unregister_filesystem(&mut *self.ptr) };
-        self.ptr = unsafe { mem::zeroed() };
     }
 }
 


### PR DESCRIPTION
Boxes form a capability about the memory they point at, so nulling one out isn't particularly coherent. Plus assigning one to be null is probably undefined behavior.