### PR TITLE
Kernel compatibility changes up to 5.2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -69,7 +69,16 @@ fn handle_kernel_version_cfg(bindings_path: &PathBuf) {
     }
     let version = version.expect("Couldn't find kernel version");
     if version >= kernel_version_code(4, 15, 0) {
-        println!("cargo:rustc-cfg=kernel_4_15_0_or_greataer")
+        println!("cargo:rustc-cfg=kernel_4_15_0_or_greater")
+    }
+    if version >= kernel_version_code(4, 19, 0) {
+        println!("cargo:rustc-cfg=kernel_4_19_0_or_greater")
+    }
+    if version >= kernel_version_code(4, 20, 0) {
+        println!("cargo:rustc-cfg=kernel_4_20_0_or_greater")
+    }
+    if version >= kernel_version_code(5, 1, 0) {
+        println!("cargo:rustc-cfg=kernel_5_1_0_or_greater")
     }
 }
 

--- a/src/chrdev.rs
+++ b/src/chrdev.rs
@@ -152,11 +152,15 @@ impl FileOperationsVtable {
             release: Some(release_callback::<T>),
 
             check_flags: None,
+            #[cfg(not(kernel_4_20_0_or_greater))]
             clone_file_range: None,
             compat_ioctl: None,
             copy_file_range: None,
+            #[cfg(not(kernel_4_20_0_or_greater))]
             dedupe_file_range: None,
             fallocate: None,
+            #[cfg(kernel_4_19_0_or_greater)]
+            fadvise: None,
             fasync: None,
             flock: None,
             flush: None,
@@ -164,14 +168,18 @@ impl FileOperationsVtable {
             get_unmapped_area: None,
             iterate: None,
             iterate_shared: None,
+            #[cfg(kernel_5_1_0_or_greater)]
+            iopoll: None,
             llseek: None,
             lock: None,
             mmap: None,
-            #[cfg(kernel_4_15_0_or_greataer)]
+            #[cfg(kernel_4_15_0_or_greater)]
             mmap_supported_flags: 0,
             owner: ptr::null_mut(),
             poll: None,
             read_iter: None,
+            #[cfg(kernel_4_20_0_or_greater)]
+            remap_file_range: None,
             sendpage: None,
             setfl: None,
             setlease: None,

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1,6 +1,7 @@
 #include <linux/bug.h>
 #include <linux/printk.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 
 
 int printk_helper(const unsigned char *s, int len)
@@ -13,7 +14,11 @@ void bug_helper(void)
     BUG();
 }
 
-int access_ok_helper(unsigned int mode, const void __user *addr, unsigned long n)
+int access_ok_helper(const void __user *addr, unsigned long n)
 {
-    return access_ok(mode, addr, n);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) /* v5.0-rc1~46 */
+    return access_ok(addr, n);
+#else
+    return access_ok(0, addr, n);
+#endif
 }

--- a/src/user_ptr.rs
+++ b/src/user_ptr.rs
@@ -7,11 +7,7 @@ use crate::c_types;
 use crate::error;
 
 extern "C" {
-    fn access_ok_helper(
-        mode: c_types::c_uint,
-        addr: *const c_types::c_void,
-        len: c_types::c_ulong,
-    ) -> c_types::c_int;
+    fn access_ok_helper(addr: *const c_types::c_void, len: c_types::c_ulong) -> c_types::c_int;
 }
 
 /// A reference to an area in userspace memory, which can be either
@@ -53,11 +49,7 @@ impl UserSlicePtr {
         ptr: *mut c_types::c_void,
         length: usize,
     ) -> error::KernelResult<UserSlicePtr> {
-        // No current access_ok implementation actually distinguishes
-        // between VERIFY_READ and VERIFY_WRITE, so passing VERIFY_WRITE
-        // is fine in practice and fails safe if a future implementation
-        // bothers.
-        if access_ok_helper(bindings::VERIFY_WRITE, ptr, length as c_types::c_ulong) == 0 {
+        if access_ok_helper(ptr, length as c_types::c_ulong) == 0 {
             return Err(error::Error::EFAULT);
         }
         Ok(UserSlicePtr(ptr, length))


### PR DESCRIPTION
* 4.19 (torvalds/linux@45cd0faa) added file_operations.fadvise
* 4.20 (torvalds/linux@2e5dfc99) turned clone_file_range and
  dedupe_file_range into remap_file_range
* 5.0 (torvalds/linux@96d4f267) removed the type argument from access_ok
* 5.1 (torvalds/linux@fb7e1600) added file_operations.iopoll

There's also a required change to kernel-cflags-finder, coming as a
separate commit.