### PR TITLE
kernel-cflags-finder: Fix build on 5.2 (fixes #124)

### DIFF
--- a/kernel-cflags-finder/Makefile
+++ b/kernel-cflags-finder/Makefile
@@ -21,7 +21,7 @@ $(if $(filter-out -I/% -I../%,$(1)),$(patsubst ./%,$(CURDIR)/%,$(patsubst -I%,-I
 our_flags = $(foreach o,$($(1)),$(call our_addtree,$(o)))
 
 $(M)/dummy.c:
-	@echo $(NOSTDINC_FLAGS) $(call our_flags,LINUXINCLUDE) $(__c_flags) $(modkern_cflags)
+	@echo $(NOSTDINC_FLAGS) $(call our_flags,LINUXINCLUDE) $(or $(__c_flags),$(_c_flags)) $(modkern_cflags)
 	@touch $@
 
 .PHONY: $(M)/dummy.c


### PR DESCRIPTION
torvalds/linux@cdd750bf gets rid of __c_flags, so just use _c_flags if
__c_flags is unset.