### PR TITLE
Make build.rs notice when kernel-cflags-finder has failed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -74,17 +74,21 @@ fn handle_kernel_version_cfg(bindings_path: &PathBuf) {
 }
 
 fn main() {
-    println!("rerun-if-env-changed=KDIR");
-    let output = String::from_utf8(
-        Command::new("make")
-            .arg("-C")
-            .arg("kernel-cflags-finder")
-            .arg("-s")
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
+    println!("cargo:rerun-if-env-changed=KDIR");
+    println!("cargo:rerun-if-env-changed=CLANG");
+    println!("cargo:rerun-if-changed=kernel-cflags-finder/Makefile");
+    let output = Command::new("make")
+        .arg("-C")
+        .arg("kernel-cflags-finder")
+        .arg("-s")
+        .output()
+        .unwrap();
+    if !output.status.success() {
+        eprintln!("kernel-cflags-finder did not succeed");
+        eprintln!("stdout: {}", std::str::from_utf8(&output.stdout).unwrap());
+        eprintln!("stderr: {}", std::str::from_utf8(&output.stderr).unwrap());
+        std::process::exit(1);
+    }
 
     let mut builder = bindgen::Builder::default()
         .use_core()
@@ -93,7 +97,7 @@ fn main() {
         .rustfmt_bindings(true);
 
     builder = builder.clang_arg("--target=x86_64-linux-kernel-module");
-    for arg in shlex::split(&output).unwrap() {
+    for arg in shlex::split(std::str::from_utf8(&output.stdout).unwrap()).unwrap() {
         builder = builder.clang_arg(arg.to_string());
     }
 
@@ -127,7 +131,7 @@ fn main() {
     builder.target("x86_64-linux-kernel-module");
     builder.warnings(false);
     builder.file("src/helpers.c");
-    for arg in shlex::split(&output).unwrap() {
+    for arg in shlex::split(std::str::from_utf8(&output.stdout).unwrap()).unwrap() {
         builder.flag(&arg);
     }
     builder.compile("helpers");

--- a/kernel-cflags-finder/Makefile
+++ b/kernel-cflags-finder/Makefile
@@ -1,6 +1,7 @@
 ifneq ($(KERNELRELEASE),)
 obj-m += dummy.o
 clean-files := dummy.c
+ccflags-y += -Wno-unknown-warning-option
 
 # Some systems for installing kernel headers (e.g. Debian's) happen to
 # trigger the out-of-tree build code because the kernel headers directly


### PR DESCRIPTION
If we get an error out of kernel-cflags-finder, we should fail early
instead of continuing the build.

Also, suppress one Clang warning class (unknown -W flags, see e.g.
torvalds/linux@9df3e7a7 - in a real clang build these wouldn't be
present but in a clang-modules-on-gcc-kernel build it shows up) to get
kernel-cflags-finder exiting cleanly on 4.20+.

Also rerun the build script if kernel-cflags-finder/Makefile has
changed, or if $CLANG, which it and bindgen both use, have changed.