### PR TITLE
Make mod error public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod allocator;
 pub mod bindings;
 mod c_types;
 pub mod chrdev;
-mod error;
+pub mod error;
 pub mod filesystem;
 pub mod printk;
 pub mod sysctl;


### PR DESCRIPTION
Motivation is json-sysctl (#122) where we need this to return things
like ENOMEM.