### PR TITLE
Remove long unused option from the target spec

### DIFF
--- a/x86_64-linux-kernel-module.json
+++ b/x86_64-linux-kernel-module.json
@@ -11,7 +11,6 @@
   "linker-is-gnu": true,
   "llvm-target": "x86_64-elf",
   "max-atomic-width": 64,
-  "no-compiler-rt": true,
   "os": "none",
   "panic-strategy": "abort",
   "position-independent-executables": true,


### PR DESCRIPTION
This has not existed since 2016, 3fd5fdd8d3e64e957a7eafe3d6d0b10ef4170d59 in rust.