### PR TITLE
[fix] Add extra macro to make builds on Debian possible

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,6 +91,8 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CLANG");
     println!("cargo:rerun-if-changed=kernel-cflags-finder/Makefile");
     let output = Command::new("make")
+	.arg("EXTRA_CFLAGS=-UCC_HAVE_ASM_GOTO -w")
+	.arg("-k")
         .arg("-C")
         .arg("kernel-cflags-finder")
         .arg("-s")


### PR DESCRIPTION
Hey,
I tried to build the project on Debian buster, and found that the `kernel-cflags-finder` doesn't compile due to `CC_HAVE_ASM_GOTO` being enabled. So, by disabling this macro, suppressing warning (`-w`), continuing build with warnings (`-k`), I was able to build it. 