### PR TITLE
Mark kernel modules as being authored by everyone

### DIFF
--- a/hello-world/src/lib.rs
+++ b/hello-world/src/lib.rs
@@ -31,7 +31,7 @@ impl Drop for HelloWorldModule {
 
 linux_kernel_module::kernel_module!(
     HelloWorldModule,
-    author: "Alex Gaynor and Geoffrey Thomas",
+    author: "Fish in a Barrel Contributors",
     description: "An extremely simple kernel module",
     license: "GPL"
 );

--- a/tests/chrdev-region-allocation/src/lib.rs
+++ b/tests/chrdev-region-allocation/src/lib.rs
@@ -21,7 +21,7 @@ impl linux_kernel_module::KernelModule for ChrdevRegionAllocationTestModule {
 
 linux_kernel_module::kernel_module!(
     ChrdevRegionAllocationTestModule,
-    author: "Alex Gaynor and Geoffrey Thomas",
+    author: "Fish in a Barrel Contributors",
     description: "A module for testing character device region allocation",
     license: "GPL"
 );

--- a/tests/chrdev/src/lib.rs
+++ b/tests/chrdev/src/lib.rs
@@ -68,7 +68,7 @@ impl linux_kernel_module::KernelModule for ChrdevTestModule {
 
 linux_kernel_module::kernel_module!(
     ChrdevTestModule,
-    author: "Alex Gaynor and Geoffrey Thomas",
+    author: "Fish in a Barrel Contributors",
     description: "A module for testing character devices",
     license: "GPL"
 );

--- a/tests/printk/src/lib.rs
+++ b/tests/printk/src/lib.rs
@@ -17,7 +17,7 @@ impl linux_kernel_module::KernelModule for PrintkTestModule {
 
 linux_kernel_module::kernel_module!(
     PrintkTestModule,
-    author: "Alex Gaynor and Geoffrey Thomas",
+    author: "Fish in a Barrel Contributors",
     description: "A module for testing println!()",
     license: "GPL"
 );

--- a/tests/sysctl-get/src/lib.rs
+++ b/tests/sysctl-get/src/lib.rs
@@ -39,7 +39,7 @@ impl Drop for SysctlGetTestModule {
 
 linux_kernel_module::kernel_module!(
     SysctlGetTestModule,
-    author: "Alex Gaynor and Geoffrey Thomas",
+    author: "Fish in a Barrel Contributors",
     description: "A module for testing sysctls",
     license: "GPL"
 );

--- a/tests/sysctl/src/lib.rs
+++ b/tests/sysctl/src/lib.rs
@@ -34,7 +34,7 @@ impl linux_kernel_module::KernelModule for SysctlTestModule {
 
 linux_kernel_module::kernel_module!(
     SysctlTestModule,
-    author: "Alex Gaynor and Geoffrey Thomas",
+    author: "Fish in a Barrel Contributors",
     description: "A module for testing sysctls",
     license: "GPL"
 );


### PR DESCRIPTION
Refs #34 

I did _not_ update the `Cargo.toml` fields, because those require an email address, and we don't have a collective one of those yet.