### PR TITLE
Only use file_operations::setfl on AUFS-patched kernels (closes #167)

### DIFF
--- a/src/chrdev.rs
+++ b/src/chrdev.rs
@@ -225,6 +225,7 @@ impl FileOperationsVtable {
             #[cfg(kernel_4_20_0_or_greater)]
             remap_file_range: None,
             sendpage: None,
+            #[cfg(kernel_aufs_setfl)]
             setfl: None,
             setlease: None,
             show_fdinfo: None,


### PR DESCRIPTION
Debian and Ubuntu, which we're using for all our CI and local dev, have
a patched kernel which adds a setfl method to struct file_operations, so
our builds don't work on unpatched (e.g., upstream) kernels. The
patchset also does an EXPORT_SYMBOL_GPL(setfl), so we can key on that to
determine whether we need to fill in the setfl method or not.

Current patches are at
https://salsa.debian.org/kernel-team/linux/tree/debian/5.2.9-2/debian/patches/features/all/aufs5