### PR TITLE
Add tests for filesystem::register

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -14,6 +14,9 @@ pub struct Registration<T: FileSystem> {
     ptr: Box<bindings::file_system_type>,
 }
 
+// This is safe because Registration doesn't actually expose any methods.
+unsafe impl<T> Sync for Registration<T> where T: FileSystem {}
+
 impl<T: FileSystem> Drop for Registration<T> {
     fn drop(&mut self) {
         unsafe { bindings::unregister_filesystem(&mut *self.ptr) };

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -23,7 +23,7 @@ impl<T: FileSystem> Drop for Registration<T> {
     }
 }
 
-pub trait FileSystem {
+pub trait FileSystem: Sync {
     const NAME: &'static CStr;
     const FLAGS: FileSystemFlags;
 }

--- a/tests/filesystem/Cargo.toml
+++ b/tests/filesystem/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "filesystem-tests"
+version = "0.1.0"
+authors = ["Luis Gerhorst <privat@luisgerhorst.de>", "Alex Gaynor <alex.gaynor@gmail.com>", "Geoffrey Thomas <geofft@ldpreload.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["staticlib"]
+test = false
+
+[features]
+default = ["linux-kernel-module"]
+
+[dependencies]
+linux-kernel-module = { path = "../..", optional = true }
+
+[dev-dependencies]
+kernel-module-testlib = { path = "../../testlib" }

--- a/tests/filesystem/src/lib.rs
+++ b/tests/filesystem/src/lib.rs
@@ -11,9 +11,6 @@ struct TestFSModule {
     _fs_registration: filesystem::Registration<TestFS>,
 }
 
-// This is safe because Registration doesn't actually expose any methods.
-unsafe impl Sync for TestFSModule {}
-
 struct TestFS {}
 
 impl FileSystem for TestFS {

--- a/tests/filesystem/src/lib.rs
+++ b/tests/filesystem/src/lib.rs
@@ -1,0 +1,38 @@
+#![no_std]
+#![feature(const_str_as_bytes)]
+#![feature(const_raw_ptr_deref)]
+
+extern crate alloc;
+
+use linux_kernel_module::filesystem::{self, FileSystem, FileSystemFlags};
+use linux_kernel_module::{self, CStr};
+
+struct TestFSModule {
+    _fs_registration: filesystem::Registration<TestFS>,
+}
+
+// This is safe because Registration doesn't actually expose any methods.
+unsafe impl Sync for TestFSModule {}
+
+struct TestFS {}
+
+impl FileSystem for TestFS {
+    const NAME: &'static CStr = unsafe { &*("testfs\x00" as *const str as *const CStr) };
+    const FLAGS: FileSystemFlags = FileSystemFlags::FS_REQUIRES_DEV;
+}
+
+impl linux_kernel_module::KernelModule for TestFSModule {
+    fn init() -> linux_kernel_module::KernelResult<Self> {
+        let fs_registration = filesystem::register::<TestFS>()?;
+        Ok(TestFSModule {
+            _fs_registration: fs_registration,
+        })
+    }
+}
+
+linux_kernel_module::kernel_module!(
+    TestFSModule,
+    author: "Fish in a Barrel Contributors",
+    description: "A module for testing filesystem::register",
+    license: "GPL"
+);

--- a/tests/filesystem/src/lib.rs
+++ b/tests/filesystem/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use linux_kernel_module::filesystem::{self, FileSystem, FileSystemFlags};
-use linux_kernel_module::{self, CStr};
+use linux_kernel_module::{self, cstr, CStr};
 
 struct TestFSModule {
     _fs_registration: filesystem::Registration<TestFS>,
@@ -14,7 +14,7 @@ struct TestFSModule {
 struct TestFS {}
 
 impl FileSystem for TestFS {
-    const NAME: &'static CStr = unsafe { &*("testfs\x00" as *const str as *const CStr) };
+    const NAME: &'static CStr = cstr!("testfs\x00");
     const FLAGS: FileSystemFlags = FileSystemFlags::FS_REQUIRES_DEV;
 }
 

--- a/tests/filesystem/src/lib.rs
+++ b/tests/filesystem/src/lib.rs
@@ -13,7 +13,7 @@ struct TestFSModule {
 struct TestFS {}
 
 impl FileSystem for TestFS {
-    const NAME: &'static CStr = cstr!("testfs\x00");
+    const NAME: &'static CStr = cstr!("testfs");
     const FLAGS: FileSystemFlags = FileSystemFlags::FS_REQUIRES_DEV;
 }
 

--- a/tests/filesystem/src/lib.rs
+++ b/tests/filesystem/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(const_str_as_bytes)]
-#![feature(const_raw_ptr_deref)]
 
 extern crate alloc;
 

--- a/tests/filesystem/tests/tests.rs
+++ b/tests/filesystem/tests/tests.rs
@@ -3,7 +3,7 @@ use std::fs;
 use kernel_module_testlib::with_kernel_module;
 
 #[test]
-fn test_register_unregister() {
+fn test_proc_filesystems() {
     let filesystems = fs::read_to_string("/proc/filesystems").unwrap();
     assert!(!filesystems.contains("testfs"));
 

--- a/tests/filesystem/tests/tests.rs
+++ b/tests/filesystem/tests/tests.rs
@@ -1,0 +1,17 @@
+use std::fs;
+
+use kernel_module_testlib::with_kernel_module;
+
+#[test]
+fn test_register_unregister() {
+    let filesystems = fs::read_to_string("/proc/filesystems").unwrap();
+    assert!(!filesystems.contains("testfs"));
+
+    with_kernel_module(|| {
+        let filesystems = fs::read_to_string("/proc/filesystems").unwrap();
+        assert!(filesystems.contains("testfs"));
+    });
+
+    let filesystems = fs::read_to_string("/proc/filesystems").unwrap();
+    assert!(!filesystems.contains("testfs"));
+}


### PR DESCRIPTION
Do so by checking whether loading the module makes the name of the filesystem
(`testfs`) appear in `/proc/filesystems`.

Fixes https://github.com/fishinabarrel/linux-kernel-module-rust/issues/93.

If someone can make a suggestion on how to remove the two `unsafe` blocks I would be happy to implement it. I tried to find a way to remove the `unsafe` block for the `CStr` but I don't think it's possible. I'm very new to Rust thought, so prove me wrong. There exists a [`const_cstr`](https://github.com/abonander/const-cstr/blob/master/src/lib.rs#L64) crate that offers a `const_cstr!` macro, maybe do something similar?