### PR TITLE
Remove unneeded FS_REQUIRES_DEV from TestFS FLAGS

### DIFF
--- a/tests/filesystem/src/lib.rs
+++ b/tests/filesystem/src/lib.rs
@@ -14,7 +14,7 @@ struct TestFS {}
 
 impl FileSystem for TestFS {
     const NAME: &'static CStr = cstr!("testfs");
-    const FLAGS: FileSystemFlags = FileSystemFlags::FS_REQUIRES_DEV;
+    const FLAGS: FileSystemFlags = FileSystemFlags::empty();
 }
 
 impl linux_kernel_module::KernelModule for TestFSModule {


### PR DESCRIPTION
See https://github.com/torvalds/linux/blob/86c2f5d653058798703549e1be39a819fcac0d5d/fs/autofs/init.c#L16 for a upstream filesystem that does also not set any flags.