### PR TITLE
`const_str_as_bytes` was stablised, but not removed from example

### DIFF
--- a/hello-world/src/lib.rs
+++ b/hello-world/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(const_str_as_bytes)]
 
 extern crate alloc;
 


### PR DESCRIPTION
As title, this is an extension of the previous commit, but for the hello world example.