### PR TITLE
Fix some compiled errors(mismatched types)

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,4 +1,5 @@
 use core::alloc::{GlobalAlloc, Layout};
+use core::convert::TryInto;
 use core::ptr;
 
 use crate::bindings;
@@ -10,7 +11,11 @@ unsafe impl GlobalAlloc for KernelAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // krealloc is used instead of kmalloc because kmalloc is an inline function and can't be
         // bound to as a result
-        bindings::krealloc(ptr::null(), layout.size(), bindings::GFP_KERNEL) as *mut u8
+        bindings::krealloc(
+            ptr::null(),
+            layout.size().try_into().unwrap(),
+            bindings::GFP_KERNEL,
+        ) as *mut u8
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {

--- a/src/sysctl.rs
+++ b/src/sysctl.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec;
+use core::convert::TryInto;
 use core::mem;
 use core::ptr;
 use core::sync::atomic;
@@ -83,7 +84,7 @@ unsafe extern "C" fn proc_handler<T: SysctlStorage>(
     ctl: *mut bindings::ctl_table,
     write: c_types::c_int,
     buffer: *mut c_types::c_void,
-    len: *mut usize,
+    len: *mut c_types::c_ulonglong,
     ppos: *mut bindings::loff_t,
 ) -> c_types::c_int {
     // If we're reading from some offset other than the beginning of the file,
@@ -93,7 +94,7 @@ unsafe extern "C" fn proc_handler<T: SysctlStorage>(
         return 0;
     }
 
-    let data = match UserSlicePtr::new(buffer, *len) {
+    let data = match UserSlicePtr::new(buffer, (*len).try_into().unwrap()) {
         Ok(ptr) => ptr,
         Err(e) => return e.to_kernel_errno(),
     };
@@ -108,7 +109,7 @@ unsafe extern "C" fn proc_handler<T: SysctlStorage>(
         let mut writer = data.writer();
         storage.read_value(&mut writer)
     };
-    *len = bytes_processed;
+    *len = bytes_processed.try_into().unwrap();
     *ppos += *len as bindings::loff_t;
     match result {
         Ok(()) => 0,


### PR DESCRIPTION
Building the hello-world module according to README.md results in errors.

# Environment
`generic/ubuntu1810` box in Vagrant with Virtualbox
```
vagrant@ubuntu1810/: uname -a
Linux ubuntu1810.localdomain 4.18.0-25-generic #26-Ubuntu SMP Mon Jun 24 09:32:08 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

vagrant@ubuntu1810:/$ clang -v
clang version 7.0.0-3 (tags/RELEASE_700/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/8
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/8
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/8
Candidate multilib: .;@m64
Selected multilib: .;@m64
 
vagrant@ubuntu1810:/$ rustup -v
rustup 1.21.1 (7832b2ebe 2019-12-20)
```

# error messages
```
$ cd linux-kernel-module-rust/hello-world
$ make
...(snip)...
error[E0308]: mismatched types
  --> /vagrant_data/linux-kernel-module-rust/src/allocator.rs:13:41
   |
13 |         bindings::krealloc(ptr::null(), layout.size(), bindings::GFP_KERNEL) as *mut u8
   |                                         ^^^^^^^^^^^^^ expected `u64`, found `usize`
   |
help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
   |
13 |         bindings::krealloc(ptr::null(), layout.size().try_into().unwrap(), bindings::GFP_KERNEL) as *mut u8
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> /vagrant_data/linux-kernel-module-rust/src/file_operations.rs:193:28
    |
193 |         self.0.read = Some(read_callback::<T>);
    |                            ^^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
    |
    = note: expected fn pointer `unsafe extern "C" fn(_, _, u64, _) -> i64`
                  found fn item `unsafe extern "C" fn(_, _, usize, _) -> isize {file_operations::read_callback::<T>}`

error[E0308]: mismatched types
   --> /vagrant_data/linux-kernel-module-rust/src/file_operations.rs:200:29
    |
200 |         self.0.write = Some(write_callback::<T>);
    |                             ^^^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
    |
    = note: expected fn pointer `unsafe extern "C" fn(_, _, u64, _) -> i64`
                  found fn item `unsafe extern "C" fn(_, _, usize, _) -> isize {file_operations::write_callback::<T>}`

error[E0308]: mismatched types
   --> /vagrant_data/linux-kernel-module-rust/src/sysctl.rs:136:36
    |
136 |                 proc_handler: Some(proc_handler::<T>),
    |                                    ^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
    |
    = note: expected fn pointer `unsafe extern "C" fn(_, _, _, *mut u64, _) -> _`
                  found fn item `unsafe extern "C" fn(_, _, _, *mut usize, _) -> _ {sysctl::proc_handler::<T>}`

error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0308`.
The following warnings were emitted during compilation:
error: could not compile `linux-kernel-module`.
...(snip)...
```
I fixed these errors with type cast and change variable type.
