### PR TITLE
kernel-cflags-finder: Set CONFIG_CC_IS_CLANG=y

### DIFF
--- a/kernel-cflags-finder/Makefile
+++ b/kernel-cflags-finder/Makefile
@@ -1,7 +1,6 @@
 ifneq ($(KERNELRELEASE),)
 obj-m += dummy.o
 clean-files := dummy.c
-ccflags-y += -Wno-unknown-warning-option
 
 # Some systems for installing kernel headers (e.g. Debian's) happen to
 # trigger the out-of-tree build code because the kernel headers directly
@@ -30,7 +29,7 @@ else
 KDIR ?= /lib/modules/$(shell uname -r)/build
 CLANG ?= clang
 all:
-	$(MAKE) -C $(KDIR) M=$(CURDIR) CC=$(CLANG)
+	$(MAKE) -C $(KDIR) M=$(CURDIR) CC=$(CLANG) CONFIG_CC_IS_CLANG=y
 clean:
 	$(MAKE) -C $(KDIR) M=$(CURDIR) clean
 endif


### PR DESCRIPTION
Some of the things in the kernel's Makefile check whether
`${CC} --version` is clang, which is affected by setting CC. Some look at
CONFIG_CC_IS_CLANG, which was set at configuration time when our kernel
was built. We need to override the latter to get clang-compatible flags.

This causes the kernel to no longer set -W / -Wno flags that aren't
valid for clang, so we can get rid of `-Wno-unknown-warning-option`.

One problem with the previous approach is that the kernel's Makefile
does feature detection to see what options are accepted by the current
compiler, and it doesn't accept custom CFLAGS early enough for them to
take effect during feature detection. Because the kernel sets
`-Werror=unknown-warning-option` for clang (by checking the version of
`${CC}`, unfortunately), all attempts at feature detection would fail
with an unrelated error. This causes Makefile to wrongly conclude that
the compiler doesn't support `-mfentry` and use mcount instead even if
the compiled kernel expects fentry - i.e., this commit fixes #174.

We might eventually need to set CONFIG_CLANG_VERSION and perhaps unset
CONFIG_CC_IS_GCC, but this seems to work well enough for now.