### PR TITLE
Unpin bindgen and use `--size_t-is-usize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 bitflags = "1"
 
 [build-dependencies]
-bindgen = "0.51.0"
+bindgen = "0.54"
 cc = "1.0"
 shlex = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -139,6 +139,7 @@ fn main() {
         .use_core()
         .ctypes_prefix("c_types")
         .derive_default(true)
+        .size_t_is_usize(true)
         .rustfmt_bindings(true);
 
     builder = builder.clang_arg(format!("--target={}", target));

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -22,3 +22,7 @@ int access_ok_helper(const void __user *addr, unsigned long n)
     return access_ok(0, addr, n);
 #endif
 }
+
+/* see https://github.com/rust-lang/rust-bindgen/issues/1671 */
+_Static_assert(__builtin_types_compatible_p(size_t, uintptr_t),
+               "size_t must match uintptr_t, what architecture is this??");


### PR DESCRIPTION
Add an assertion that doing so is safe.
See rust-lang/rust-bindgen#1671

Can't use static_assert from <linux/build_bug.h> because that's
5.1+-only, but the underlying _Static_assert compiler builtin is
available widely.
See torvalds/linux@6bab69c65013bed5fce9f101a64a84d0385b3946