### PR TITLE
Run cargo clippy from inside Kbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ script:
           (cd "$p" && cargo fmt --all -- --check) || exit 1
         fi
       done
-    - cargo clippy -- -D warnings
 
 after_failure:
     - dmesg

--- a/hello-world/Kbuild
+++ b/hello-world/Kbuild
@@ -4,7 +4,7 @@ helloworld-objs := hello_world.rust.o
 CARGO ?= cargo
 
 $(src)/target/x86_64-linux-kernel/debug/libhello_world.a: $(src)/Cargo.toml $(wildcard $(src)/src/*.rs)
-	cd $(src); env -u MAKE -u MAKEFLAGS $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel
+	cd $(src); $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel
 
 %.rust.o: target/x86_64-linux-kernel/debug/lib%.a
 	$(LD) -r -o $@ --whole-archive $<

--- a/hello-world/src/lib.rs
+++ b/hello-world/src/lib.rs
@@ -5,7 +5,6 @@ extern crate alloc;
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 
-use linux_kernel_module;
 use linux_kernel_module::println;
 
 struct HelloWorldModule {

--- a/tests/Kbuild
+++ b/tests/Kbuild
@@ -4,7 +4,8 @@ testmodule-objs := $(TEST_NAME).rust.o
 CARGO ?= cargo
 
 $(src)/target/x86_64-linux-kernel/debug/lib%.a: $(src)/$(TEST_PATH)/Cargo.toml $(wildcard $(src)/$(TEST_PATH)/src/*.rs)
-	cd $(src)/$(TEST_PATH); env -u MAKE -u MAKEFLAGS CARGO_TARGET_DIR=../target $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel
+	cd $(src)/$(TEST_PATH); CARGO_TARGET_DIR=../target $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel
+	cd $(src)/$(TEST_PATH); CARGO_TARGET_DIR=../target $(CARGO) clippy -Z build-std=core,alloc --target=x86_64-linux-kernel -- -Dwarnings
 
 %.rust.o: target/x86_64-linux-kernel/debug/lib%.a
 	$(LD) -r -o $@ --whole-archive $<

--- a/tests/chrdev/src/lib.rs
+++ b/tests/chrdev/src/lib.rs
@@ -16,7 +16,7 @@ impl linux_kernel_module::file_operations::FileOperations for CycleFile {
             .build();
 
     fn open() -> linux_kernel_module::KernelResult<Self> {
-        return Ok(CycleFile);
+        Ok(CycleFile)
     }
 }
 impl linux_kernel_module::file_operations::Read for CycleFile {
@@ -34,7 +34,7 @@ impl linux_kernel_module::file_operations::Read for CycleFile {
         {
             buf.write(&[*c])?;
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -47,7 +47,7 @@ impl linux_kernel_module::file_operations::FileOperations for SeekFile {
             .build();
 
     fn open() -> linux_kernel_module::KernelResult<Self> {
-        return Ok(SeekFile);
+        Ok(SeekFile)
     }
 }
 
@@ -57,7 +57,7 @@ impl linux_kernel_module::file_operations::Seek for SeekFile {
         _file: &linux_kernel_module::file_operations::File,
         _offset: linux_kernel_module::file_operations::SeekFrom,
     ) -> linux_kernel_module::KernelResult<u64> {
-        return Ok(1234);
+        Ok(1234)
     }
 }
 
@@ -73,9 +73,9 @@ impl linux_kernel_module::file_operations::FileOperations for WriteFile {
             .build();
 
     fn open() -> linux_kernel_module::KernelResult<Self> {
-        return Ok(WriteFile {
+        Ok(WriteFile {
             written: AtomicUsize::new(0),
-        });
+        })
     }
 }
 
@@ -88,7 +88,7 @@ impl linux_kernel_module::file_operations::Read for WriteFile {
     ) -> linux_kernel_module::KernelResult<()> {
         let val = self.written.load(Ordering::SeqCst).to_string();
         buf.write(val.as_bytes())?;
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -100,7 +100,7 @@ impl linux_kernel_module::file_operations::Write for WriteFile {
     ) -> linux_kernel_module::KernelResult<()> {
         let data = buf.read_all()?;
         self.written.fetch_add(data.len(), Ordering::SeqCst);
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/tests/modinfo/src/lib.rs
+++ b/tests/modinfo/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use linux_kernel_module;
-
 struct ModinfoTestModule;
 
 impl linux_kernel_module::KernelModule for ModinfoTestModule {

--- a/tests/printk/src/lib.rs
+++ b/tests/printk/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(clippy::print_literal)]
 
 use linux_kernel_module::{self, println};
 

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use linux_kernel_module;
-
 struct UtilsTestModule;
 
 #[allow(dead_code)]


### PR DESCRIPTION
Once we do #191, build.rs needs to run inside Kbuild (since it can no
longer call out to kernel-cflags-finder), and clippy is unable to run if
build.rs doesn't run.

Also, fix up clippy warnings about our actual modules, not just the
framework.