### PR TITLE
Add backwards compatbility down to kernel 4.4 (fixes #199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ concurrently (such as by implementing locking).
 ## System requirements
 
 We're currently only running CI on Linux 4.15 (Ubuntu Xenial) on amd64,
-although we try to keep support for newer (and perhaps older) kernels
-working. Other architectures should work but are untested - see
-[#112](https://github.com/fishinabarrel/linux-kernel-module-rust/issues/112)
-for expected status.
+although we intend to support kernels from 4.4 through the latest
+release. Please report a bug (or better yet, send in a patch!) if your
+kernel doesn't work.
+
+Other architectures aren't implemented yet, but should work as long as
+there's Rust and LLVM support - see [#112]
+(https://github.com/fishinabarrel/linux-kernel-module-rust/issues/112)
+for expected status. They'll need src/c_types.rs ported, too.
 
 You'll need to have [Rust](https://www.rust-lang.org) - in particular
 Rust nightly, as we use [some unstable
@@ -54,6 +58,9 @@ you're running kernel 5.0 or newer, [you'll need Clang
 (released September 2019), which adds support for `asm goto`.
 You may need to set the `CLANG` environment variable appropriately,
 e.g., `CLANG=clang-9`.
+
+Very recent kernels may require newer versions of Clang - try Clang 11
+if older versions don't work for you.
 
 ## Building hello-world
 

--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,18 @@ fn handle_kernel_version_cfg(bindings_path: &PathBuf) {
         }
     }
     let version = version.expect("Couldn't find kernel version");
+    if version >= kernel_version_code(4, 5, 0) {
+        println!("cargo:rustc-cfg=kernel_4_5_0_or_greater")
+    }
+    if version >= kernel_version_code(4, 7, 0) {
+        println!("cargo:rustc-cfg=kernel_4_7_0_or_greater")
+    }
+    if version >= kernel_version_code(4, 9, 0) {
+        println!("cargo:rustc-cfg=kernel_4_9_0_or_greater")
+    }
+    if version >= kernel_version_code(4, 13, 0) {
+        println!("cargo:rustc-cfg=kernel_4_13_0_or_greater")
+    }
     if version >= kernel_version_code(4, 15, 0) {
         println!("cargo:rustc-cfg=kernel_4_15_0_or_greater")
     }

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -144,12 +144,15 @@ impl FileOperationsVtable {
                 open: Some(open_callback::<T>),
                 release: Some(release_callback::<T>),
 
+                #[cfg(not(kernel_4_9_0_or_greater))]
+                aio_fsync: None,
                 check_flags: None,
-                #[cfg(not(kernel_4_20_0_or_greater))]
+                #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
                 clone_file_range: None,
                 compat_ioctl: None,
+                #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
                 copy_file_range: None,
-                #[cfg(not(kernel_4_20_0_or_greater))]
+                #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
                 dedupe_file_range: None,
                 fallocate: None,
                 #[cfg(kernel_4_19_0_or_greater)]
@@ -160,6 +163,7 @@ impl FileOperationsVtable {
                 fsync: None,
                 get_unmapped_area: None,
                 iterate: None,
+                #[cfg(kernel_4_7_0_or_greater)]
                 iterate_shared: None,
                 #[cfg(kernel_5_1_0_or_greater)]
                 iopoll: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 pub mod file_operations;
 pub mod filesystem;
 pub mod printk;
+#[cfg(kernel_4_13_0_or_greater)]
 pub mod random;
 pub mod sysctl;
 mod types;


### PR DESCRIPTION
4.5 added
 * copy_file_range (torvalds/linux@29732938a6289a15e907da234d6692a2ead71855)
 * clone_file_range (torvalds/linux@04b38d601239b4d9be641b412cf4b7456a041c67)
 * dedupe_file_range (torvalds/linux@54dbc15172375641ef03399e8f911d7165eb90fb)

4.7 added iterate_shared (torvalds/linux@6192269444ebfbfb42e23c7a6a93c76ffe4b5e51),
a variant of iterate that takes a non-exclusive lock. It sounds like
it'd be safe to provide an implementation of iterate_shared as iterate.

4.9 removed aio_fsync (torvalds/linux@723c038475b78edc9327eb952f95f9881cc9d79d),
which was never actually used, so we can set it to None in older kernels
and not think about it.

4.13 added wait_for_random_bytes (torvalds/linux@e297a783e41560b44e3c14f38e420cba518113b8).
For now, conditionalize the entire random module on it.

All test cases other than random pass on Ubuntu 16.04's kernel.

Update the README to say we expect 4.4 onwards to work, possibly with
newer Clang for really new kernels (refs #219).