### PR TITLE
file_operations: Restore copy_file_range

### DIFF
--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -150,7 +150,7 @@ impl FileOperationsVtable {
                 #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
                 clone_file_range: None,
                 compat_ioctl: None,
-                #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
+                #[cfg(kernel_4_5_0_or_greater)]
                 copy_file_range: None,
                 #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
                 dedupe_file_range: None,


### PR DESCRIPTION
This was a copy/paste mistake, copy_file_range (unlike clone_file_range
/ dedupe_file_range) still exists in current kernels and so it needs
only a lower bound.

Fixes: 240393d3 ("Add backwards compatbility down to kernel 4.4 (fixes #199)")