### PR TITLE
Go back to using KDIR to find the kernel sources (fixes #243)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -137,10 +137,10 @@ fn prepare_cflags(cflags: &str, kernel_dir: &str) -> Vec<String> {
 
 fn main() {
     println!("cargo:rerun-if-env-changed=CC");
-    println!("cargo:rerun-if-env-changed=abs_srctree");
+    println!("cargo:rerun-if-env-changed=KDIR");
     println!("cargo:rerun-if-env-changed=c_flags");
 
-    let kernel_dir = env::var("abs_srctree").expect("Must be invoked from kernel makefile");
+    let kernel_dir = env::var("KDIR").expect("Must be invoked from kernel makefile");
     let kernel_cflags = env::var("c_flags").expect("Add 'export c_flags' to Kbuild");
 
     let kernel_args = prepare_cflags(&kernel_cflags, &kernel_dir);

--- a/hello-world/Kbuild
+++ b/hello-world/Kbuild
@@ -4,7 +4,6 @@ helloworld-objs := hello_world.rust.o
 CARGO ?= cargo
 
 export c_flags
-export abs_srctree ?= ${CURDIR}
 
 $(src)/target/x86_64-linux-kernel/debug/libhello_world.a: $(src)/Cargo.toml $(wildcard $(src)/src/*.rs)
 	cd $(src); $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,4 +1,4 @@
-KDIR ?= /lib/modules/$(shell uname -r)/build
+export KDIR ?= /lib/modules/$(shell uname -r)/build
 
 CLANG ?= clang
 ifeq ($(origin CC),default)

--- a/tests/Kbuild
+++ b/tests/Kbuild
@@ -4,7 +4,6 @@ testmodule-objs := $(TEST_NAME).rust.o
 CARGO ?= cargo
 
 export c_flags
-export abs_srctree ?= ${CURDIR}
 
 $(src)/target/x86_64-linux-kernel/debug/lib%.a: $(src)/$(TEST_PATH)/Cargo.toml $(wildcard $(src)/$(TEST_PATH)/src/*.rs)
 	cd $(src)/$(TEST_PATH); CARGO_TARGET_DIR=../target $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-KDIR ?= /lib/modules/$(shell uname -r)/build
+export KDIR ?= /lib/modules/$(shell uname -r)/build
 
 CLANG ?= clang
 ifeq ($(origin CC),default)


### PR DESCRIPTION
On Debian, abs_srctree points to /usr/share/linux-headers-x.y-common,
which doesn't have generated arch-specific headers. We previously ran
into a similar problem in kernel-cflags-finder regarding expanding
includes in the right directory (see the comment in b6378909).

abs_objtree seems to work but I'm not sure that's reliable, it sounds
like it's usable for out-of-tree builds in some fashion. CURDIR would
work, but since we're using KDIR in the parent Makefile which does a
`make -C $(KDIR)`, we may as well export and use that variable.