### PR TITLE
build.rs: Add KBUILD_CFLAGS_MODULE to cflags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -142,8 +142,11 @@ fn main() {
 
     let kernel_dir = env::var("abs_srctree").expect("Must be invoked from kernel makefile");
     let kernel_cflags = env::var("c_flags").expect("Add 'export c_flags' to Kbuild");
+    let kbuild_cflags_module =
+        env::var("KBUILD_CFLAGS_MODULE").expect("Must be invoked from kernel makefile");
 
-    let kernel_args = prepare_cflags(&kernel_cflags, &kernel_dir);
+    let cflags = format!("{} {}", kernel_cflags, kbuild_cflags_module);
+    let kernel_args = prepare_cflags(&cflags, &kernel_dir);
 
     let target = env::var("TARGET").unwrap();
 


### PR DESCRIPTION
KBUILD_CFLAGS_MODULE=-DMODULE isn't included in c_flags anymore on Linux 5.4+
due to some Makefile refactoring. We just do it ourselves for now.

Fixes #241.