### PR TITLE
Fix clippy lints in file_operations.rs

### DIFF
--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -144,17 +144,17 @@ impl<T: FileOperations> FileOperationsVtable<T> {
     pub(crate) const VTABLE: bindings::file_operations = bindings::file_operations {
         open: Some(open_callback::<T>),
         release: Some(release_callback::<T>),
-        read: if let Some(_) = T::READ {
+        read: if T::READ.is_some() {
             Some(read_callback::<T>)
         } else {
             None
         },
-        write: if let Some(_) = T::WRITE {
+        write: if T::WRITE.is_some() {
             Some(write_callback::<T>)
         } else {
             None
         },
-        llseek: if let Some(_) = T::SEEK {
+        llseek: if T::SEEK.is_some() {
             Some(llseek_callback::<T>)
         } else {
             None


### PR DESCRIPTION
The tests where failing, like due to the introduction of new clippy lints.
This PR fixes the affected lines, such that the tests pass again.