### PR TITLE
build.rs: Build fixes for Centos 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 bitflags = "1"
 
 [build-dependencies]
-bindgen = "0.54"
+bindgen = "0.56"
 cc = "1.0"
 shlex = "0.1"

--- a/hello-world/Kbuild
+++ b/hello-world/Kbuild
@@ -6,7 +6,7 @@ CARGO ?= cargo
 export c_flags
 
 $(src)/target/x86_64-linux-kernel/debug/libhello_world.a: cargo_will_determine_dependencies
-	cd $(src); $(CARGO) build -Z build-std=core,alloc --target=x86_64-linux-kernel
+	cd $(src); $(CARGO) +nightly build -Z build-std=core,alloc --target=x86_64-linux-kernel
 
 .PHONY: cargo_will_determine_dependencies
 

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,12 +1,23 @@
 export KDIR ?= /lib/modules/$(shell uname -r)/build
 
+CONFIG_CC_IS_CLANG := y
 CLANG ?= clang
 ifeq ($(origin CC),default)
 CC := ${CLANG}
 endif
 
+HEADER_SEMVER ?= $(shell uname -r | grep -oG "[0-9]\+\.[0-9]\+\.[0-9]\+" | head -1)
+ifeq ($(shell echo $(HEADER_SEMVER) 4.4.0 | tr " " "\n" | sort -V | head -1), $(HEADER_SEMVER))
+CC := gcc
+CONFIG_CC_IS_CLANG := n
+endif
+
+ifneq (,$(wildcard /etc/centos-release))
+KCPPFLAGS += -DOS_CENTOS
+endif
+
 all:
-	$(MAKE) -C $(KDIR) M=$(CURDIR) CC=$(CC) CONFIG_CC_IS_CLANG=y
+	$(MAKE) -C $(KDIR) M=$(CURDIR) CC=$(CC) KCPPFLAGS=$(KCPPFLAGS) CONFIG_CC_IS_CLANG=$(CONFIG_CC_IS_CLANG)
 
 clean:
 	$(MAKE) -C $(KDIR) M=$(CURDIR) CC=$(CC) clean

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -159,19 +159,24 @@ impl<T: FileOperations> FileOperationsVtable<T> {
         } else {
             None
         },
-
+        #[cfg(not(kernel_4_1_0_or_greater))]
+        aio_read: None,
+        #[cfg(not(kernel_4_1_0_or_greater))]
+        aio_write: None,
+        #[cfg(not(kernel_3_11_0_or_greater))]
+        readdir: None,
         #[cfg(not(kernel_4_9_0_or_greater))]
         aio_fsync: None,
         check_flags: None,
-        #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
+        #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater), not(os_centos)))]
         clone_file_range: None,
         compat_ioctl: None,
         #[cfg(kernel_4_5_0_or_greater)]
         copy_file_range: None,
-        #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater)))]
+        #[cfg(all(kernel_4_5_0_or_greater, not(kernel_4_20_0_or_greater), not(os_centos)))]
         dedupe_file_range: None,
         fallocate: None,
-        #[cfg(kernel_4_19_0_or_greater)]
+        #[cfg(any(kernel_4_19_0_or_greater, all(os_centos, kernel_4_18_0_or_greater)))]
         fadvise: None,
         fasync: None,
         flock: None,
@@ -181,7 +186,7 @@ impl<T: FileOperations> FileOperationsVtable<T> {
         iterate: None,
         #[cfg(kernel_4_7_0_or_greater)]
         iterate_shared: None,
-        #[cfg(kernel_5_1_0_or_greater)]
+        #[cfg(any(kernel_5_1_0_or_greater, all(os_centos, kernel_4_18_0_or_greater)))]
         iopoll: None,
         lock: None,
         mmap: None,
@@ -189,18 +194,32 @@ impl<T: FileOperations> FileOperationsVtable<T> {
         mmap_supported_flags: 0,
         owner: ptr::null_mut(),
         poll: None,
+        #[cfg(kernel_3_16_0_or_greater)]
         read_iter: None,
-        #[cfg(kernel_4_20_0_or_greater)]
+        #[cfg(any(kernel_4_20_0_or_greater, all(os_centos, kernel_4_18_0_or_greater)))]
         remap_file_range: None,
         sendpage: None,
         #[cfg(kernel_aufs_setfl)]
         setfl: None,
+        #[cfg(all(not(kernel_4_18_0_or_greater), os_centos))]
+        __bindgen_anon_1: bindings::file_operations__bindgen_ty_1 { setlease: None },
+        #[cfg(any(kernel_4_18_0_or_greater, not(os_centos)))]
         setlease: None,
         show_fdinfo: None,
         splice_read: None,
         splice_write: None,
         unlocked_ioctl: None,
+        #[cfg(kernel_3_16_0_or_greater)]
         write_iter: None,
+
+        #[cfg(all(os_centos, kernel_4_18_0_or_greater))]
+        rh_reserved1: 0,
+        #[cfg(all(os_centos, kernel_4_18_0_or_greater))]
+        rh_reserved2: 0,
+        #[cfg(all(os_centos, kernel_4_18_0_or_greater))]
+        rh_reserved3: 0,
+        #[cfg(all(os_centos, kernel_4_18_0_or_greater))]
+        rh_reserved4: 0,
     };
 }
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -3,7 +3,6 @@
 #include <linux/uaccess.h>
 #include <linux/version.h>
 
-
 void bug_helper(void)
 {
     BUG();
@@ -11,7 +10,9 @@ void bug_helper(void)
 
 int access_ok_helper(const void __user *addr, unsigned long n)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) /* v5.0-rc1~46 */
+#if defined(OS_CENTOS) && LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+    return access_ok(addr, n);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) /* v5.0-rc1~46 */
     return access_ok(addr, n);
 #else
     return access_ok(0, addr, n);


### PR DESCRIPTION
Hello. Our team is implementing kernel module on rust for developed device. But we need to support multiple Linux distributions (to be precise: CentOS 7/8, Ubuntu 18/20, Debian 10). The problem is that CentOS 7 has really old kernel version as default that can not be compiled by clang (thus parsed by libclang in bindgen) as is. This patch allows to build Hello-World on CentOS 7 with old kernel.